### PR TITLE
Auth fixes

### DIFF
--- a/src/Application/BaseApplication.php
+++ b/src/Application/BaseApplication.php
@@ -354,7 +354,9 @@ abstract class BaseApplication implements ApplicationInterface, ApplicationAware
             $this->events[$eventName] = [];
         }
 
-        $this->events[$eventName][] = $listenerClass;
+        if (in_array($listenerClass, $this->events[$eventName]) === false) {
+            $this->events[$eventName][] = $listenerClass;
+        }
 
         return $this;
     }

--- a/src/Mailer/Mail.php
+++ b/src/Mailer/Mail.php
@@ -37,8 +37,8 @@ class Mail implements MailInterface
      * @var array
      */
     private $options = [
-        'cc' => '',
-        'bcc' => '',
+        'cc' => null,
+        'bcc' => null,
     ];
 
     /**

--- a/test/Event/EventsTest.php
+++ b/test/Event/EventsTest.php
@@ -70,9 +70,9 @@ class EventsTest extends UnitTest
     }
 
     /**
-     * Test application->triggerEvent() - with few listeners - success
+     * Test application->listen() - with same listener multiple times on one hook - only one registered
      */
-    public function testApplicationTriggerEventWithFewListeners()
+    public function testApplicationRegisterOneListenerMultipleTimesOnSameHook()
     {
         $app = $this->getApplication();
         for ($i = 0; $i < 5; $i ++) {
@@ -83,10 +83,6 @@ class EventsTest extends UnitTest
 
         $this->assertEquals(
             [
-                'Test Payload',
-                'Test Payload',
-                'Test Payload',
-                'Test Payload',
                 'Test Payload'
             ],
             $out


### PR DESCRIPTION
- fixed bug that allowed registering one listener on one hook multiple times
  in `BaseApplication`
- `cc` and `bcc` parameters of `options` var of `Mail` class now default to null
  instead of empty string
- `EventsTest` fix