### PR TITLE
Config refactor

### DIFF
--- a/src/Application/ApplicationInterface.php
+++ b/src/Application/ApplicationInterface.php
@@ -31,9 +31,16 @@ interface ApplicationInterface
     public function run(): ApplicationInterface;
 
     /**
-     * @return Bootstrap
+     * Instantiates `Bootstrap`, loads modules configs
      */
-    public function bootstrap(): Bootstrap;
+    public function initialize();
+
+    /**
+     * Registers everything to application
+     *
+     * @return ApplicationInterface
+     */
+    public function bootstrap(): ApplicationInterface;
 
     /**
      * @param string $eventName

--- a/src/Application/BaseApplication.php
+++ b/src/Application/BaseApplication.php
@@ -129,6 +129,11 @@ abstract class BaseApplication implements ApplicationInterface, ApplicationAware
     private $httpClient = null;
 
     /**
+     * @var Bootstrap
+     */
+    private $bootstrap = null;
+
+    /**
      * Has to build instance of RequestInterface, set it to BaseApplication and return it
      * @return RequestInterface
      */
@@ -149,7 +154,7 @@ abstract class BaseApplication implements ApplicationInterface, ApplicationAware
 
         $this->setRootPath()
              ->setExceptionHandler(new ExceptionHandler())
-             ->bootstrap();
+             ->initialize();
     }
 
     /**
@@ -187,20 +192,28 @@ abstract class BaseApplication implements ApplicationInterface, ApplicationAware
     }
 
     /**
-     * @return Bootstrap
+     *
      */
-    public function bootstrap(): Bootstrap
+    public function initialize()
     {
         $this->servicesRegistry = new ServicesRegistry();
         $this->servicesRegistry->setApplication($this);
 
-        $bootstrap = new Bootstrap();
-        $registerModules = $this->getConfiguration()
-                                ->getRegisteredModules();
+        $this->bootstrap = new Bootstrap();
+        $registeredModules = $this->getConfiguration()
+                                  ->getRegisteredModules();
 
-        $bootstrap->registerModules($registerModules, $this);
+        $this->bootstrap->loadModulesConfigs($registeredModules, $this);
+    }
 
-        return $bootstrap;
+    /**
+     * @return ApplicationInterface
+     */
+    public function bootstrap(): ApplicationInterface
+    {
+        $this->bootstrap->registerModules();
+
+        return $this;
     }
 
     /**

--- a/src/Application/Bootstrap.php
+++ b/src/Application/Bootstrap.php
@@ -2,6 +2,8 @@
 
 namespace Framework\Base\Application;
 
+use Framework\Base\Module\ModuleInterface;
+
 /**
  * Class Bootstrap
  * @package Framework\Base\Application
@@ -9,9 +11,9 @@ namespace Framework\Base\Application;
 class Bootstrap
 {
     /**
-     * @var array
+     * @var ModuleInterface[]
      */
-    private $registerModules = [];
+    private $modules = [];
 
     /**
      * @param array           $moduleInterfaceClassNames
@@ -19,15 +21,27 @@ class Bootstrap
      *
      * @return Bootstrap
      */
-    public function registerModules(array $moduleInterfaceClassNames, BaseApplication $application): Bootstrap
+    public function loadModulesConfigs(array $moduleInterfaceClassNames, BaseApplication $application): Bootstrap
     {
-        $this->registerModules = $moduleInterfaceClassNames;
+        foreach ($moduleInterfaceClassNames as $moduleClass) {
+            /* @var \Framework\Base\Module\ModuleInterface $module */
+            $module = new $moduleClass();
+            $module->setApplication($application)
+                   ->loadConfig();
 
-        foreach ($this->registerModules as $moduleClass) {
-            /* @var \Framework\Base\Module\ModuleInterface $instance */
-            $instance = new $moduleClass();
-            $instance->setApplication($application);
-            $instance->bootstrap();
+            $this->modules[] = $module;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return Bootstrap
+     */
+    public function registerModules(): Bootstrap
+    {
+        foreach ($this->modules as $module) {
+            $module->bootstrap();
         }
 
         return $this;

--- a/src/Module.php
+++ b/src/Module.php
@@ -2,6 +2,8 @@
 
 namespace Framework\Base;
 
+use Framework\Base\Application\ApplicationConfigurationInterface;
+use Framework\Base\Application\ApplicationInterface;
 use Framework\Base\Module\BaseModule;
 
 /**
@@ -13,10 +15,75 @@ class Module extends BaseModule
     /**
      * @inheritdoc
      */
-    public function bootstrap()
+    public function loadConfig()
     {
         // Let's read all files from module config folder and set to Configuration
         $configDirPath = realpath(dirname(__DIR__)) . '/config/';
         $this->setModuleConfiguration($configDirPath);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function bootstrap()
+    {
+        /**
+         * @var ApplicationInterface $application
+         */
+        $application = $this->getApplication();
+
+        /**
+         * @var ApplicationConfigurationInterface $appConfig
+         */
+        $appConfig = $application->getConfiguration();
+
+        $repositoryManager = $application->getRepositoryManager();
+
+        // Add listeners to application
+        if (
+            empty($listeners = $appConfig->getPathValue('listeners')) === false
+        ) {
+            foreach ($listeners as $event => $arrayHandlers) {
+                foreach ($arrayHandlers as $handlerClass) {
+                    $application->listen($event, $handlerClass);
+                }
+            }
+        }
+
+        //Register Services
+        if (
+            empty($services = $appConfig->getPathValue('services')) === false
+        ) {
+            foreach ($services as $serviceName => $config) {
+                $application->registerService(new $serviceName($config));
+            }
+        }
+
+        // Register repositories
+        if (
+            empty($repositories = $appConfig->getPathValue('repositories')) === false
+        ) {
+            $repositoryManager->registerRepositories($repositories);
+        }
+
+        // Register model adapters
+        if (
+            empty($modelAdapters = $appConfig->getPathValue('modelAdapters')) === false
+        ) {
+            foreach ($modelAdapters as $model => $adapters) {
+                foreach ($adapters as $adapter) {
+                    $repositoryManager->addModelAdapter($model, new $adapter());
+                }
+            }
+        }
+
+        // Register model primary adapters
+        if (
+            empty($primaryModelAdapter = $appConfig->getPathValue('primaryModelAdapter')) === false
+        ) {
+            foreach ($primaryModelAdapter as $model => $primaryAdapter) {
+                $repositoryManager->setPrimaryAdapter($model, new $primaryAdapter());
+            }
+        }
     }
 }

--- a/src/Module/BaseModule.php
+++ b/src/Module/BaseModule.php
@@ -69,4 +69,10 @@ abstract class BaseModule implements ModuleInterface
 
         return $files;
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function bootstrap()
+    {}
 }

--- a/src/Module/ModuleInterface.php
+++ b/src/Module/ModuleInterface.php
@@ -11,6 +11,11 @@ use Framework\Base\Application\ApplicationAwareInterface;
 interface ModuleInterface extends ApplicationAwareInterface
 {
     /**
+     * Load module configuration into application configuration instance
+     */
+    public function loadConfig();
+
+    /**
      * Bootstrap module
      */
     public function bootstrap();

--- a/test/UnitTest.php
+++ b/test/UnitTest.php
@@ -35,7 +35,9 @@ class UnitTest extends TestCase
 
         $appConfig = new ApplicationConfiguration();
 
-        $this->setApplication(new DummyApplication($appConfig));
+        $this->setApplication(
+            (new DummyApplication($appConfig))->bootstrap()
+        );
     }
 
     /**


### PR DESCRIPTION
- `ApplicationInterface` method `bootstrap()` split to `initialize()` and `bootstrap()`
- `BaseApplication` implementations `initialize()` called in constructor and
  `bootstrap()` must be specifically called before `run()`
- `Bootstrap` class is now saved to app
- `Bootstrap` method `registerModules()` split to `loadModulesConfigs()`
  and `registerModules()`
- `Bootstrap` now saves instances of modules to itself
- `loadConfig()` declared in `ModuleInterface`, now every module has to have its own
  implementation
- base module `Module` now registers services, listeners, primary and database adapters
  and repositories

[TASK](http://platform.the-shop.io/projects/59954b113e5bbe5dc215d4c9/sprints/59fb21013e5bbe20f2257a91/tasks/5a33d91773a19407d83c75c8)